### PR TITLE
chore: pnpm を v11.1.1 にアップグレード

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
 save-exact=true
-engine-strict=true
-auto-install-peers=true
-minimum-release-age=10080

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kizami",
   "version": "0.1.0",
   "type": "module",
-  "packageManager": "pnpm@10.33.1",
+  "packageManager": "pnpm@11.1.1",
   "engines": {
     "node": "24.13.0"
   },
@@ -35,14 +35,5 @@
     "typescript-eslint": "8.57.2",
     "vite": "6.4.2",
     "vitest": "3.2.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "onnxruntime-node"
-    ],
-    "overrides": {
-      "protobufjs@<7.5.5": "^7.5.5"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+autoInstallPeers: true
+engineStrict: true
+minimumReleaseAge: 10080
+allowBuilds:
+  better-sqlite3: true
+  onnxruntime-node: true
+  esbuild: false
+  protobufjs: false
+  sharp: false
+overrides:
+  protobufjs@<7.5.5: ^7.5.5


### PR DESCRIPTION
## 概要

サプライチェーン攻撃対策の強化を目的に、pnpm を **v10.33.1 → v11.1.1** へアップグレードします。

## pnpm 11 で得られる主な防御強化

| 設定 | 既定値 | 効果 |
|---|---|---|
| \`minimumReleaseAge\` | 1440 分 (1日) | 公開直後の新バージョンを解決しない (本リポジトリでは元々 10080 分 = 1週間に設定済みのため追加メリットは限定的) |
| \`blockExoticSubdeps\` | \`true\` | 推移的依存が Git URL / tarball URL から解決されるのをブロック (今回新規) |
| \`strictDepBuilds\` | \`true\` | ビルドスクリプトを許可していない依存が現れた場合に install を失敗させる (今回新規) |

特に \`strictDepBuilds\` のデフォルト有効化により、想定外のビルドスクリプトが silently に実行されることを防げます。

## 変更点

### 1. \`packageManager\` の更新
- \`pnpm@10.33.1\` → \`pnpm@11.1.1\`

### 2. pnpm 固有設定を \`pnpm-workspace.yaml\` へ集約
pnpm 11 では \`package.json\` の \`pnpm\` フィールドが読まれなくなり、設定は \`pnpm-workspace.yaml\` に集約する方針に変更されました。
- \`package.json\` の \`pnpm.onlyBuiltDependencies\` → \`allowBuilds\` (map 形式) に書き換え
- \`package.json\` の \`pnpm.overrides\` → \`pnpm-workspace.yaml\` へ移動
- \`.npmrc\` の pnpm 固有キー (\`engine-strict\` / \`auto-install-peers\` / \`minimum-release-age\`) → \`pnpm-workspace.yaml\` へ移動 (\`.npmrc\` には \`save-exact\` のみ残置)

### 3. \`allowBuilds\` の明示
\`strictDepBuilds: true\` のデフォルト化に伴い、ビルドスクリプトを持つ依存はすべて許可/拒否を明示する必要があります。元の \`onlyBuiltDependencies\` の挙動 (ネイティブバインディング系のみ実行許可) を保持するため、以下を設定:
- \`better-sqlite3\`: \`true\` (ネイティブビルド必須)
- \`onnxruntime-node\`: \`true\` (ネイティブビルド必須)
- \`esbuild\` / \`protobufjs\` / \`sharp\`: \`false\` (実行不要)

## 互換性チェック

- ✅ Node.js: 24.13.0 (pnpm 11 の要件 Node 22+ を満たす)
- ✅ \`pnpm-lock.yaml\`: lockfileVersion 9 のまま互換 (再生成不要、差分なし)
- ✅ corepack 経由で \`pnpm@11.1.1\` を有効化済み

## 品質ゲート

\`pnpm check\` (\`install --frozen-lockfile\` → \`typecheck\` → \`lint\` → \`format\` → \`test\` → \`build\`) を完走させて確認:

- ✅ \`pnpm install --frozen-lockfile\`: 成功 (lockfile 不変)
- ✅ \`tsc --noEmit\`: エラーなし
- ✅ \`eslint src/\`: エラーなし
- ✅ \`prettier --check src/ tests/\`: フォーマット OK
- ✅ \`vitest run\`: **171 passed | 12 skipped** (20 test files)
- ✅ \`vite build\`: 成功 (\`dist/cli.js\` 71.88 kB)

## 参考リンク

- [pnpm 11.0 リリースノート](https://pnpm.io/blog/releases/11.0)
- [pnpm Supply Chain Security](https://pnpm.io/supply-chain-security)