### PR TITLE
docs(readme): specify exact predecessor versions (v0.1.1/v0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ kizami setup
   - SessionEnd hookでセッション終了時に会話を自動保存します
   - UserPromptSubmit hookでプロンプト送信時に関連記憶を自動注入します
 
-### v0.1.x からのアップグレード
+### v0.1.1 / v0.1.2 からのアップグレード
 
-JSONL正本化のため、既存ユーザーは初回起動時に以下のコマンドでマイグレーションを実行してください。
+JSONL正本化のため、v0.1.1 または v0.1.2 から v0.2.0 に上げる既存ユーザーは初回起動時に以下のコマンドでマイグレーションを実行してください。
 
 ```bash
 kizami migrate-to-jsonl
@@ -218,7 +218,7 @@ kizami rebuild --from-month 2026-05  # 特定月のみ
 
 embedding が JSONL にインライン保存されている場合、モデルロード不要で復元されます (1000チャンクで実測 約55ms)。
 
-### SQLite→JSONLマイグレーション (v0.1.x→v0.2.0)
+### SQLite→JSONLマイグレーション (v0.1.1/v0.1.2 → v0.2.0)
 
 ```bash
 kizami migrate-to-jsonl


### PR DESCRIPTION
## Summary

`v0.1.x` という総称表記を、実在するリリース (`v0.1.1`, `v0.1.2`) を明示する形に置き換える docs-only な修正です。

### 経緯

v0.2.0 リリース直後、ユーザーから「`kizami --version` が `0.1.2` を返す」というレポートがありました。調査の結果:

- origin/main の `package.json` は `0.2.0`、タグ `v0.2.0` も commit `8262000` に正しく付与済みで、**タグとアプリのバージョンは完全に一致**
- ユーザーのローカルが古いビルド (PR 時点の dist/cli.js, version=0.1.2) を参照していただけ
- main を pull + `pnpm build` で `kizami --version` が `0.2.0` を返すことを実機確認済み

ただしこのやり取りの中で、READMEの「v0.1.x からのアップグレード」という総称表記が「実在バージョンを曖昧にする」というフィードバックを受けたため、実在する v0.1.1 / v0.1.2 を明示する形に修正します。

### 変更点

| Before | After |
|---|---|
| `### v0.1.x からのアップグレード` | `### v0.1.1 / v0.1.2 からのアップグレード` |
| `### SQLite→JSONLマイグレーション (v0.1.x→v0.2.0)` | `### SQLite→JSONLマイグレーション (v0.1.1/v0.1.2 → v0.2.0)` |

## Test plan

- [x] docs-only 変更のため `pnpm check` は影響なし
- [x] semantic-release は `docs:` を採番対象外と扱うため追加リリース発火なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)