### PR TITLE
fix: kimi-code save機能を実装(pending file + wire.jsonl抽出)

### DIFF
--- a/src/hooks/kimi.ts
+++ b/src/hooks/kimi.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { createHash } from 'node:crypto';
 
@@ -104,7 +105,7 @@ export function savePendingKimiPrompt(
   };
 
   fs.mkdirSync(pendingDir, { recursive: true });
-  const key = `${safeFilePart(input.session_id)}-${hashText(prompt)}`;
+  const key = `${safeFilePart(input.session_id)}-${hashText(`${pending.createdAt}\0${prompt}`)}`;
   fs.writeFileSync(path.join(pendingDir, `${key}.json`), JSON.stringify(pending), {
     encoding: 'utf-8',
     mode: 0o600,
@@ -181,7 +182,8 @@ export function extractAssistantFromWireJsonl(wirePath: string): string {
 }
 
 export function findWireJsonlPath(sessionId: string, kimiHomeDir?: string): string | undefined {
-  const home = kimiHomeDir ?? path.join(process.env['HOME'] ?? '', '.kimi-code');
+  const home =
+    kimiHomeDir ?? process.env['KIMI_CODE_HOME'] ?? path.join(os.homedir(), '.kimi-code');
   const sessionsDir = path.join(home, 'sessions');
   if (!fs.existsSync(sessionsDir)) return undefined;
 

--- a/src/hooks/kimi.ts
+++ b/src/hooks/kimi.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+
 export interface KimiBaseInput {
   hook_event_name?: string;
   session_id: string;
@@ -50,4 +54,142 @@ export function parseKimiPromptInput(raw: string): KimiPromptInput | null {
   } catch {
     return null;
   }
+}
+
+export function parseKimiSessionEndInput(raw: string): KimiSessionEndInput | null {
+  if (!raw) return null;
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof data.session_id !== 'string' || !data.session_id) return null;
+    return {
+      hook_event_name: typeof data.hook_event_name === 'string' ? data.hook_event_name : undefined,
+      session_id: data.session_id,
+      cwd: typeof data.cwd === 'string' ? data.cwd : undefined,
+      reason: typeof data.reason === 'string' ? data.reason : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+interface PendingKimiTurn {
+  sessionId: string;
+  cwd: string;
+  prompt: string;
+  createdAt: string;
+}
+
+const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
+
+function safeFilePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.-]/g, '_');
+}
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
+}
+
+export function savePendingKimiPrompt(
+  input: { session_id: string; cwd?: string; prompt?: string },
+  pendingDir: string
+): void {
+  const prompt = input.prompt?.trim();
+  if (!prompt) return;
+
+  const pending: PendingKimiTurn = {
+    sessionId: input.session_id,
+    cwd: input.cwd ?? process.cwd(),
+    prompt,
+    createdAt: new Date().toISOString(),
+  };
+
+  fs.mkdirSync(pendingDir, { recursive: true });
+  const key = `${safeFilePart(input.session_id)}-${hashText(prompt)}`;
+  fs.writeFileSync(path.join(pendingDir, `${key}.json`), JSON.stringify(pending), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+}
+
+export function collectPendingKimiTurns(
+  sessionId: string,
+  pendingDir: string,
+  cleanup = false
+): PendingKimiTurn[] {
+  if (!fs.existsSync(pendingDir)) return [];
+
+  const prefix = `${safeFilePart(sessionId)}-`;
+  const now = Date.now();
+  const results: PendingKimiTurn[] = [];
+
+  for (const entry of fs.readdirSync(pendingDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.startsWith(prefix) || !entry.name.endsWith('.json'))
+      continue;
+
+    const filePath = path.join(pendingDir, entry.name);
+    try {
+      const pending = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as PendingKimiTurn;
+      const age = now - new Date(pending.createdAt).getTime();
+      if (age > PENDING_TTL_MS) {
+        if (cleanup) fs.rmSync(filePath, { force: true });
+        continue;
+      }
+      results.push(pending);
+      if (cleanup) fs.rmSync(filePath, { force: true });
+    } catch {
+      if (cleanup) fs.rmSync(filePath, { force: true });
+    }
+  }
+
+  return results.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+export function extractAssistantFromWireJsonl(wirePath: string): string {
+  let content: string;
+  try {
+    content = fs.readFileSync(wirePath, 'utf-8');
+  } catch {
+    return '';
+  }
+
+  const lines = content.trim().split('\n');
+  let textParts: string[] = [];
+
+  for (const line of lines) {
+    let entry: {
+      type?: string;
+      event?: { type?: string; part?: { type?: string; text?: string } };
+    };
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (entry.type !== 'context.append_loop_event') continue;
+    const evt = entry.event;
+    if (!evt) continue;
+
+    if (evt.type === 'step.begin') {
+      textParts = [];
+    } else if (evt.type === 'content.part' && evt.part?.type === 'text' && evt.part.text) {
+      textParts.push(evt.part.text);
+    }
+  }
+
+  return textParts.join('').trim();
+}
+
+export function findWireJsonlPath(sessionId: string, kimiHomeDir?: string): string | undefined {
+  const home = kimiHomeDir ?? path.join(process.env['HOME'] ?? '', '.kimi-code');
+  const sessionsDir = path.join(home, 'sessions');
+  if (!fs.existsSync(sessionsDir)) return undefined;
+
+  for (const wdDir of fs.readdirSync(sessionsDir, { withFileTypes: true })) {
+    if (!wdDir.isDirectory()) continue;
+    const sessionDir = path.join(sessionsDir, wdDir.name, sessionId);
+    const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+    if (fs.existsSync(wirePath)) return wirePath;
+  }
+  return undefined;
 }

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { loadConfig } from '@/config';
 import { getDatabase } from '@/db/connection';
 import { initializeSchema } from '@/db/schema';
@@ -9,7 +10,7 @@ import { rankResults, applyProjectPenalty, reciprocalRankFusion } from '@/search
 import { formatResults } from '@/search/formatter';
 import { recoverTranscripts } from '@/hooks/recover';
 import { savePendingCodexPrompt } from '@/hooks/codex';
-import { parseKimiPromptInput } from '@/hooks/kimi';
+import { parseKimiPromptInput, savePendingKimiPrompt } from '@/hooks/kimi';
 
 export type HookRuntime = 'claude' | 'codex' | 'kimi';
 
@@ -137,6 +138,9 @@ export async function runRecall(
       if (!kimiInput) return;
       const prompt = kimiInput.prompt;
       if (!prompt) return;
+      const config = loadConfig(configPath);
+      const pendingDir = path.join(path.dirname(config.database.path), 'pending', 'kimi');
+      savePendingKimiPrompt(kimiInput, pendingDir);
       const input = { prompt, session_id: kimiInput.session_id, cwd: kimiInput.cwd };
       const result = await handleRecall(input, configPath, projectOverride);
       if (result) process.stdout.write(result);

--- a/src/hooks/save.ts
+++ b/src/hooks/save.ts
@@ -185,7 +185,7 @@ async function handleKimiSessionEnd(raw: string, configPath?: string): Promise<v
 
   const config = loadConfig(configPath);
   const pendingDir = path.join(path.dirname(config.database.path), 'pending', 'kimi');
-  const turns = collectPendingKimiTurns(parsed.session_id, pendingDir, true);
+  const turns = collectPendingKimiTurns(parsed.session_id, pendingDir, false);
   if (turns.length === 0) return;
 
   const wirePath = findWireJsonlPath(parsed.session_id);
@@ -245,12 +245,16 @@ async function handleKimiSessionEnd(raw: string, configPath?: string): Promise<v
       createdAt,
     };
 
-    const inserted = store.appendChunksWithoutReplace([chunk]);
-    if (inserted === 0) return;
-
     const writer = new JsonlWriter(config.storage.jsonlDir);
     writer.appendRecords(chunksToJsonlRecords([chunk], embeddings));
 
+    const inserted = store.appendChunksWithoutReplace([chunk]);
+    if (inserted === 0) {
+      collectPendingKimiTurns(parsed.session_id, pendingDir, true);
+      return;
+    }
+
+    collectPendingKimiTurns(parsed.session_id, pendingDir, true);
     runAutoMaintenance(store, config);
   } finally {
     db.close();

--- a/src/hooks/save.ts
+++ b/src/hooks/save.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { loadConfig } from '@/config';
 import { getDatabase } from '@/db/connection';
@@ -11,6 +12,14 @@ import { JsonlWriter } from '@/jsonl/writer';
 import { chunksToJsonlRecords } from '@/jsonl/converter';
 import { selfHealFromJsonl } from '@/jsonl/self_heal';
 import { handleCodexStop } from '@/hooks/codex';
+import {
+  parseKimiSessionEndInput,
+  collectPendingKimiTurns,
+  findWireJsonlPath,
+  extractAssistantFromWireJsonl,
+} from '@/hooks/kimi';
+import { extractMetadata } from '@/parser/metadata';
+import type { Chunk } from '@/db/store';
 import type { HookRuntime } from '@/hooks/recall';
 
 async function readStdin(): Promise<string> {
@@ -131,7 +140,7 @@ export async function runSave(configPath?: string, runtime: HookRuntime = 'claud
   try {
     const raw = await readStdin();
     if (runtime === 'kimi') {
-      process.stderr.write('kizami save: kimi runtime is not yet supported (Phase 2)\n');
+      await handleKimiSessionEnd(raw, configPath);
       return;
     }
     if (runtime === 'codex') {
@@ -155,5 +164,95 @@ export async function runSave(configPath?: string, runtime: HookRuntime = 'claud
   } catch (err) {
     process.stderr.write(`kizami save error: ${String(err)}\n`);
     process.exit(0);
+  }
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function resolveProjectPath(rawPath: string): string {
+  try {
+    return fs.realpathSync(rawPath);
+  } catch {
+    return rawPath;
+  }
+}
+
+async function handleKimiSessionEnd(raw: string, configPath?: string): Promise<void> {
+  const parsed = parseKimiSessionEndInput(raw);
+  if (!parsed) return;
+
+  const config = loadConfig(configPath);
+  const pendingDir = path.join(path.dirname(config.database.path), 'pending', 'kimi');
+  const turns = collectPendingKimiTurns(parsed.session_id, pendingDir, true);
+  if (turns.length === 0) return;
+
+  const wirePath = findWireJsonlPath(parsed.session_id);
+  const assistantText = wirePath ? extractAssistantFromWireJsonl(wirePath) : '';
+
+  const projectPath = resolveProjectPath(parsed.cwd ?? turns[0].cwd);
+  const allPrompts = turns.map((t) => t.prompt).join('\n\n');
+  const content = assistantText
+    ? `[User]\n${allPrompts}\n\n[Assistant]\n${assistantText}`
+    : `[User]\n${allPrompts}`;
+
+  if (!assistantText) return;
+
+  const db = getDatabase(config.database.path);
+  try {
+    initializeSchema(db);
+    const store = new Store(db);
+    try {
+      selfHealFromJsonl(store, config.storage.jsonlDir, config.storage.selfHealTailLines);
+    } catch {
+      /* non-blocking */
+    }
+
+    const createdAt = new Date().toISOString();
+    const { createHash } = await import('node:crypto');
+    const externalId = `kimi-${createHash('sha256').update(parsed.session_id).update('\0').update(allPrompts).update('\0').update(assistantText).digest('hex').slice(0, 32)}`;
+
+    if (store.getChunkIdByExternalId(externalId) !== undefined) return;
+
+    const metadata = {
+      ...extractMetadata(content),
+      sourceRuntime: 'kimi',
+      captureMethod: 'hooks',
+    };
+
+    const embeddings = new Map<number, { vec: Float32Array; model: string }>();
+    if (config.search.mode === 'hybrid') {
+      try {
+        initializeHybridSchema(db, config.embedding.dimensions);
+        const { getEmbedding } = await import('../search/embedding');
+        const vec = await getEmbedding('検索文書: ' + content.slice(0, 512), config);
+        embeddings.set(0, { vec, model: config.embedding.model });
+      } catch (err) {
+        process.stderr.write(`kizami kimi hybrid embedding error (skipped): ${String(err)}\n`);
+      }
+    }
+
+    const chunk: Chunk = {
+      externalId,
+      sessionId: parsed.session_id,
+      projectPath,
+      chunkIndex: store.getMaxChunkIndex(parsed.session_id) + 1,
+      content,
+      role: 'mixed',
+      metadata,
+      tokenCount: estimateTokens(content),
+      createdAt,
+    };
+
+    const inserted = store.appendChunksWithoutReplace([chunk]);
+    if (inserted === 0) return;
+
+    const writer = new JsonlWriter(config.storage.jsonlDir);
+    writer.appendRecords(chunksToJsonlRecords([chunk], embeddings));
+
+    runAutoMaintenance(store, config);
+  } finally {
+    db.close();
   }
 }

--- a/src/hooks/setup.ts
+++ b/src/hooks/setup.ts
@@ -271,6 +271,14 @@ function setupKimiHooks(options?: SetupOptions): void {
   const kimiConfigPath = options?.kimiConfigPath ?? getDefaultKimiConfigPath(scope);
   const kizamiCommand = getKizamiCommand(options);
 
+  const errorLogPath = path.join(
+    process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share'),
+    'kizami',
+    'error.log'
+  );
+  const escapedErrorLogPath = errorLogPath.replace(/'/g, "'\\''");
+  const escapedKizamiCommand = kizamiCommand.replace(/'/g, "'\\''");
+
   const hooks: TomlHook[] = [
     {
       event: 'SessionStart',
@@ -281,6 +289,10 @@ function setupKimiHooks(options?: SetupOptions): void {
       event: 'UserPromptSubmit',
       command: `${kizamiCommand} recall --stdin --runtime kimi`,
       timeout: 5,
+    },
+    {
+      event: 'SessionEnd',
+      command: `bash -c 'INPUT=$(cat); (printf "%s" "$INPUT" | ${escapedKizamiCommand} save --stdin --runtime kimi >/dev/null 2>> "${escapedErrorLogPath}" &); exit 0'`,
     },
   ];
 

--- a/tests/hooks/kimi.test.ts
+++ b/tests/hooks/kimi.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from 'vitest';
-import { parseKimiSessionStartInput, parseKimiPromptInput } from '../../src/hooks/kimi';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import {
+  parseKimiSessionStartInput,
+  parseKimiPromptInput,
+  parseKimiSessionEndInput,
+  savePendingKimiPrompt,
+  collectPendingKimiTurns,
+  extractAssistantFromWireJsonl,
+} from '../../src/hooks/kimi';
 
 describe('parseKimiSessionStartInput', () => {
   it('should parse valid SessionStart JSON', () => {
@@ -84,5 +94,144 @@ describe('parseKimiPromptInput', () => {
 
   it('should return null for invalid JSON', () => {
     expect(parseKimiPromptInput('{bad')).toBeNull();
+  });
+});
+
+describe('parseKimiSessionEndInput', () => {
+  it('should parse valid SessionEnd JSON', () => {
+    const raw = JSON.stringify({
+      hook_event_name: 'SessionEnd',
+      session_id: 'sess_abc',
+      cwd: '/project',
+      reason: 'exit',
+    });
+    const result = parseKimiSessionEndInput(raw);
+    expect(result).not.toBeNull();
+    expect(result!.session_id).toBe('sess_abc');
+    expect(result!.reason).toBe('exit');
+  });
+
+  it('should return null when session_id is missing', () => {
+    expect(parseKimiSessionEndInput(JSON.stringify({ reason: 'exit' }))).toBeNull();
+  });
+});
+
+describe('pending file operations', () => {
+  let tmpDir: string;
+  let pendingDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kizami-kimi-'));
+    pendingDir = path.join(tmpDir, 'pending', 'kimi');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should save and collect pending prompts for a session', () => {
+    savePendingKimiPrompt(
+      { session_id: 'sess_1', cwd: '/project', prompt: 'What is this?' },
+      pendingDir
+    );
+    savePendingKimiPrompt(
+      { session_id: 'sess_1', cwd: '/project', prompt: 'How to fix?' },
+      pendingDir
+    );
+    const turns = collectPendingKimiTurns('sess_1', pendingDir);
+    expect(turns).toHaveLength(2);
+  });
+
+  it('should not collect turns from other sessions', () => {
+    savePendingKimiPrompt({ session_id: 'sess_1', cwd: '/project', prompt: 'Q1' }, pendingDir);
+    savePendingKimiPrompt({ session_id: 'sess_2', cwd: '/project', prompt: 'Q2' }, pendingDir);
+    expect(collectPendingKimiTurns('sess_1', pendingDir)).toHaveLength(1);
+  });
+
+  it('should skip pending files older than 24 hours', () => {
+    savePendingKimiPrompt({ session_id: 'sess_1', cwd: '/project', prompt: 'old' }, pendingDir);
+    const files = fs.readdirSync(pendingDir);
+    const filePath = path.join(pendingDir, files[0]);
+    const pending = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    pending.createdAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    fs.writeFileSync(filePath, JSON.stringify(pending));
+    expect(collectPendingKimiTurns('sess_1', pendingDir)).toHaveLength(0);
+  });
+
+  it('should not save when prompt is empty', () => {
+    savePendingKimiPrompt({ session_id: 'sess_1', cwd: '/project', prompt: '' }, pendingDir);
+    expect(fs.existsSync(pendingDir)).toBe(false);
+  });
+
+  it('should clean up collected pending files', () => {
+    savePendingKimiPrompt({ session_id: 'sess_1', cwd: '/project', prompt: 'Q1' }, pendingDir);
+    collectPendingKimiTurns('sess_1', pendingDir, true);
+    const remaining = fs.readdirSync(pendingDir).filter((f) => f.includes('sess_1'));
+    expect(remaining).toHaveLength(0);
+  });
+});
+
+describe('extractAssistantFromWireJsonl', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kizami-wire-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeWire(entries: object[]): string {
+    const wirePath = path.join(tmpDir, 'wire.jsonl');
+    fs.writeFileSync(wirePath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+    return wirePath;
+  }
+
+  it('should extract last assistant text from content.part events', () => {
+    const wp = writeWire([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'content.part', part: { type: 'text', text: 'Hello, ' } },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'content.part', part: { type: 'text', text: 'world!' } },
+      },
+    ]);
+    expect(extractAssistantFromWireJsonl(wp)).toBe('Hello, world!');
+  });
+
+  it('should extract only the last turn after step.begin', () => {
+    const wp = writeWire([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'content.part', part: { type: 'text', text: 'first' } },
+      },
+      { type: 'context.append_loop_event', event: { type: 'step.end' } },
+      { type: 'context.append_loop_event', event: { type: 'step.begin' } },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'content.part', part: { type: 'text', text: 'second' } },
+      },
+    ]);
+    expect(extractAssistantFromWireJsonl(wp)).toBe('second');
+  });
+
+  it('should skip think parts', () => {
+    const wp = writeWire([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'content.part', part: { type: 'think', think: 'hmm' } },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'content.part', part: { type: 'text', text: 'answer' } },
+      },
+    ]);
+    expect(extractAssistantFromWireJsonl(wp)).toBe('answer');
+  });
+
+  it('should return empty string for nonexistent file', () => {
+    expect(extractAssistantFromWireJsonl('/nonexistent')).toBe('');
   });
 });

--- a/tests/hooks/setup.test.ts
+++ b/tests/hooks/setup.test.ts
@@ -184,6 +184,7 @@ describe('setupHooks', () => {
     expect(content).toContain('# END kizami-managed');
     expect(content).toContain('event = "SessionStart"');
     expect(content).toContain('event = "UserPromptSubmit"');
+    expect(content).toContain('event = "SessionEnd"');
     expect(content).toContain('--runtime kimi');
   });
 
@@ -216,7 +217,7 @@ describe('setupHooks', () => {
     const status = getSetupStatus({ target: 'kimi', kimiConfigPath });
     expect(status).toHaveLength(1);
     expect(status[0].target).toBe('kimi');
-    expect(status[0].hookCount).toBe(2);
+    expect(status[0].hookCount).toBe(3);
     expect(status[0].installed).toBe(true);
   });
 


### PR DESCRIPTION
## 概要

kimi-code v0.11.0のSessionEnd hookを利用した会話保存(save)機能を実装する。PR#14(v0.4.1)のPhase 1(inject + recall)に続くPhase 2。

## 背景

kimi-codeのStop/SessionEndイベントにはassistant応答(`last_assistant_message`相当)が含まれないことを実機検証で確認した。代替策としてkimi-codeのwire.jsonlファイルからassistant応答を抽出する方式を採用する。

### 実機検証結果(v0.11.0)

```json
// Stop stdin
{ "hook_event_name": "Stop", "session_id": "...", "cwd": "...", "stop_hook_active": false }

// SessionEnd stdin
{ "hook_event_name": "SessionEnd", "session_id": "...", "cwd": "...", "reason": "exit" }
```

いずれもassistant応答フィールドなし。

## 変更内容

### `src/hooks/kimi.ts`
- `parseKimiSessionEndInput`: SessionEnd stdinパーサー
- `savePendingKimiPrompt`: UserPromptSubmit時にpromptをpending fileに保存
- `collectPendingKimiTurns`: session_idフィルタ+24時間TTLでpending files回収
- `extractAssistantFromWireJsonl`: wire.jsonlのcontent.partイベントからassistantテキストを抽出
- `findWireJsonlPath`: kimi-codeのsessionsディレクトリからwire.jsonlを検索

### `src/hooks/recall.ts`
- kimi分岐でrecall実行前にpromptをpending fileに保存するよう変更

### `src/hooks/save.ts`
- Phase 2 stubを`handleKimiSessionEnd`に置換
- SessionEnd時: pending files回収→wire.jsonlからassistant抽出→chunk保存→JSONL書き出し
- assistant応答が取得できない場合はchunkを作成しない(品質防護)

### `src/hooks/setup.ts`
- `setupKimiHooks`にSessionEnd hook追加(background subshell方式)

### テスト
- `tests/hooks/kimi.test.ts`: 12テスト追加(SessionEndパース、pending file CRUD、wire.jsonl抽出)
- `tests/hooks/setup.test.ts`: hookCount=3に更新、SessionEnd含有の確認追加

## save方式の詳細

```
UserPromptSubmit         SessionEnd
       │                      │
       ▼                      ▼
  pending file          pending回収(cleanup=true)
  に保存                      │
                              ▼
                    wire.jsonl からassistant抽出
                    (~/.kimi-code/sessions/*/
                     agents/main/wire.jsonl)
                              │
                              ▼
                    Q&A chunk生成→DB+JSONL保存
```

## テスト結果

- 全260テストPass(12テスト追加)
- TypeScript typecheck Pass
- ESLint 0エラー
- secretlint + gitleaks Pass
- ビルド成功

## Test plan

- [x] `pnpm typecheck` Pass
- [x] `pnpm test` 260 Pass / 0 Fail
- [x] `pnpm lint` 0 errors
- [x] `pnpm build` 成功
- [x] pre-commit全Pass
- [x] kimi-code実機検証: Stop/SessionEnd stdinスキーマ確認済み
- [x] kimi-code実機検証: hooks発火確認済み(UserPromptSubmit `<hook_result>`注入確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kimi runtime with automatic session end handling
  * Implemented persistent storage of pending prompts and session data
  * Integrated Kimi hook configuration for seamless session management

* **Tests**
  * Expanded test coverage for Kimi runtime features and session workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->